### PR TITLE
Update examples to use dummy masses

### DIFF
--- a/run/prescan_example.sh
+++ b/run/prescan_example.sh
@@ -1,2 +1,2 @@
 
-python ../python/prescan.py -X 1000 -S 300 -n 10
+python ../python/prescan.py -X 1001 -S 301 -n 10 -f

--- a/run/scan_example.sh
+++ b/run/scan_example.sh
@@ -1,2 +1,2 @@
 
-python ../python/scan.py -X 1000 -S 300 -n 10 -i 2
+python ../python/scan.py -X 1001 -S 301 -n 10 -i 2


### PR DESCRIPTION
This will prevent the example scripts from overwriting large outputs that have already been made. The -f option has been added to the prescan example to force overwriting the dummy masses for easier testing